### PR TITLE
Fix for free variable

### DIFF
--- a/org-table-comment.el
+++ b/org-table-comment.el
@@ -383,6 +383,7 @@ Zero or below is considered a non-permissive comment
 (defvar org-table-comment-at-beginning nil)
 
 (defvar org-table-comment-at-end nil)
+(defvar org-table-comment-pre-point nil)
 
 (defun org-table-comment-pre-command ()
   "Pre-command called for `orgtbl-comment-mode'"


### PR DESCRIPTION
Declare org-table-comment-pre-command as global variable.
